### PR TITLE
Allow empty 'private_key'

### DIFF
--- a/bruv.py
+++ b/bruv.py
@@ -96,6 +96,8 @@ def get_data_store():
     return DBMDataStore(db_path)
 
 def get_private_key():
+    if not pkey_path:
+        return None
     agent = paramiko.agent.Agent()
     keys_by_path = {key.get_name(): key for key in agent.get_keys()}
     if pkey_path in keys_by_path:


### PR DESCRIPTION
By setting private_key to '' or null in the configuration file (but it
has to be set since the default isn't changed) None is passed to
paramiko, and then the default is taken (e.g. ssh agent).