### PR TITLE
Fix sorting, and make default sort as lastUpdated

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -54,7 +54,7 @@ table tr:nth-child(even) {
 <th/>
 <th ng-click="changeOrderTo('bugs')">Bugs</th>
 </tr>
-<tr ng-repeat="(number, change) in changes | orderBy:orderField:reversed" ng-class="{'selected': change.number == selectedNumber }" ng-click="setSelected(change.number)">
+<tr ng-repeat="change in changes_array | orderBy:orderField:reversed" ng-class="{'selected': change.number == selectedNumber }" ng-click="setSelected(change.number)">
 <td>{{ change.number }}</td>
 <td>{{ flags(change) }}</td>
 <td>{{ change.subject }}</td>
@@ -77,10 +77,11 @@ var app = angular.module('bruv', ["isteven-multi-select", "ngProgress", "toastr"
 app.controller('changesCtrl', ['$scope', '$document', '$http', "ngProgressFactory", 'toastr', function($scope, $document, $http, $ngProgressFactory, $toastr) {
     // Sorting
     $scope.reversed = true
+    $scope.orderField = 'lastUpdated';
     $scope.changeOrderTo = function(newOrderField) {
         if ($scope.orderField == newOrderField) {
             if ($scope.reversed) {
-                $scope.orderField = null
+                $scope.orderField = 'lastUpdated'
             } else {
                 $scope.reversed = true
             }
@@ -93,7 +94,8 @@ app.controller('changesCtrl', ['$scope', '$document', '$http', "ngProgressFactor
     $scope.markAsRead = function(number) {
         $http.get("read/" + number);
         delete $scope.changes[number];
-        $scope.change_count = Object.keys($scope.changes).length;
+        $scope.changes_array = Object.values($scope.changes);
+        $scope.change_count = $scope.changes_array.length;
     };
     // Refresh view
     $scope.isLoading = 0;
@@ -128,7 +130,8 @@ app.controller('changesCtrl', ['$scope', '$document', '$http', "ngProgressFactor
                     angular.forEach(response.data, function(change) {
                         $scope.changes[change.number] = change;
                     });
-                    $scope.change_count = Object.keys($scope.changes).length;
+                    $scope.changes_array = Object.values($scope.changes);
+                    $scope.change_count = $scope.changes_array.length;
                     $scope.decLoading();
                 }, function(response) {
                     // Failure


### PR DESCRIPTION
Sorting was broken in previous commits. This change fixes that. It also
sets the default sort to last update time, since that seems like a
healthy default.